### PR TITLE
Add null coalescing operator to asset list builder

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## 2.0.1
+- [BUGFIX] Add null coalescing operator to `$options['asset_limit']` in `AssetListBuilder:getList()`
+
 ## Migrating from Version 1.x to Version 2.0.0
 
 ### Global Changes

--- a/src/DsTrinityDataBundle/Service/Builder/AssetListBuilder.php
+++ b/src/DsTrinityDataBundle/Service/Builder/AssetListBuilder.php
@@ -55,7 +55,7 @@ class AssetListBuilder implements DataBuilderInterface
     protected function getList(array $options): Asset\Listing
     {
         $allowedTypes = $options['asset_types'];
-        $limit = $options['asset_limit'];
+        $limit = $options['asset_limit'] ?? 0;
         $additionalParams = $options['asset_additional_params'];
 
         $list = new Asset\Listing();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Add null coalescing operator to `$options['asset_limit']` in `AssetListBuilder:getList()`
