### PR TITLE
check option availability

### DIFF
--- a/src/DsTrinityDataBundle/Service/Builder/AssetListBuilder.php
+++ b/src/DsTrinityDataBundle/Service/Builder/AssetListBuilder.php
@@ -55,7 +55,7 @@ class AssetListBuilder implements DataBuilderInterface
     protected function getList(array $options): Asset\Listing
     {
         $allowedTypes = $options['asset_types'];
-        $limit = $options['asset_limit'];
+        $limit = $options['asset_limit'] ?? 0;
         $additionalParams = $options['asset_additional_params'];
 
         $list = new Asset\Listing();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

This fixes warnings / errors when processing the index queue for assets:
`ERROR    : Error while validate resource candidate: Warning: Undefined array key "asset_limit"  ["trinity_data","default"]`

