### PR TITLE
null as allowed type

### DIFF
--- a/src/DsTrinityDataBundle/Resource/FieldTransformer/Common/NormalizerValueCallback.php
+++ b/src/DsTrinityDataBundle/Resource/FieldTransformer/Common/NormalizerValueCallback.php
@@ -13,7 +13,7 @@ class NormalizerValueCallback implements FieldTransformerInterface
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setRequired(['value']);
-        $resolver->setAllowedTypes('value', ['string']);
+        $resolver->setAllowedTypes('value', ['string', 'null']);
         $resolver->setDefaults(['value' => null]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

This PR fixes the error `The option "value" with value null is expected to be of type "string", but is of type "null"`
which appears if the `normalizer_value_callback` data transformer is called with a null value.
Calling this normalizer with a null value might sound wrong, but this case is possible.
Considering the following:
some uses a data_transformer config like below, and `$normalizerOptions['locale']` is non-existent:
```
'data_transformer' => [
    'type' => 'normalizer_value_callback',
    'configuration' => ['value' => $normalizerOptions['locale'] ?? null]
]
```
Also, allowing a null value for an option which defaults to null is just right! 