### PR TITLE
move index types out of compiler pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,23 +73,23 @@ dynamic_search:
 
 ### always
 
-| Name                               | Default Value                         | Description |
-|:-----------------------------------|:--------------------------------------|:------------|
-| `index_asset`                      | false                                 |             |
-| `asset_data_builder_identifier`    | true                                  |             |
-| `asset_types`                      | `Asset::$types[]`, except folder      |             |
-| `asset_additional_params`          | []                                    |             |
-|                                    |                                       |             |
-| `index_object`                     | false                                 |             |
-| `object_data_builder_identifier`   | 'default'                             |             |
-| `object_types`                     | `DataObject::$types[]`, except folder |             |
-| `object_class_names`               | []                                    |             |
-| `object_additional_params`         | []                                    |             |
-|                                    |                                       |             |
-| `index_document`                   | false                                 |             |
-| `document_data_builder_identifier` | 'default'                             |             |
-| `document_types`                   | `Document::$types`, except folder     |             |
-| `document_additional_params`       | []                                    |             |
+| Name                               | Default Value                           | Description |
+|:-----------------------------------|:----------------------------------------|:------------|
+| `index_asset`                      | false                                   |             |
+| `asset_data_builder_identifier`    | true                                    |             |
+| `asset_types`                      | `Asset::getTypes()`, except folder      |             |
+| `asset_additional_params`          | []                                      |             |
+|                                    |                                         |             |
+| `index_object`                     | false                                   |             |
+| `object_data_builder_identifier`   | 'default'                               |             |
+| `object_types`                     | `DataObject::getTypes()`, except folder |             |
+| `object_class_names`               | []                                      |             |
+| `object_additional_params`         | []                                      |             |
+|                                    |                                         |             |
+| `index_document`                   | false                                   |             |
+| `document_data_builder_identifier` | 'default'                               |             |
+| `document_types`                   | `Document::getTypes()`, except folder   |             |
+| `document_additional_params`       | []                                      |             |
 
 ### full_dispatch
 

--- a/src/Provider/TrinityDataProvider.php
+++ b/src/Provider/TrinityDataProvider.php
@@ -32,24 +32,18 @@ class TrinityDataProvider implements DataProviderInterface, DataProviderValidati
                     'index_asset'                      => false,
                     'asset_data_builder_identifier'    => 'default',
                     'asset_additional_params'          => [],
-                    'asset_types'                      => array_filter(Asset::getTypes(), static function ($type) {
-                        return $type !== 'folder';
-                    }),
+                    'asset_types'                      => null,
                     // objects
                     'index_object'                     => false,
                     'object_data_builder_identifier'   => 'default',
                     'object_class_names'               => [],
                     'object_additional_params'         => [],
-                    'object_types'                     => array_filter(DataObject::getTypes(), static function ($type) {
-                        return $type !== 'folder';
-                    }),
+                    'object_types'                     => null,
                     // documents
                     'index_document'                   => false,
                     'document_data_builder_identifier' => 'default',
                     'document_additional_params'       => [],
-                    'document_types'                   => array_filter(Document::getTypes(), static function ($type) {
-                        return $type !== 'folder';
-                    })
+                    'document_types'                   => null
                 ];
 
                 $spoolResolver->setDefaults($options);
@@ -138,5 +132,4 @@ class TrinityDataProvider implements DataProviderInterface, DataProviderValidati
         $this->dataProvider->setContextDispatchType($contextDefinition->getContextDispatchType());
         $this->dataProvider->setIndexOptions($this->options);
     }
-
 }

--- a/src/Service/Builder/AssetListBuilder.php
+++ b/src/Service/Builder/AssetListBuilder.php
@@ -73,8 +73,14 @@ class AssetListBuilder implements DataBuilderInterface
         return $list;
     }
 
-    protected function addAssetTypeRestriction(Asset\Listing $listing, array $allowedTypes): Asset\Listing
+    protected function addAssetTypeRestriction(Asset\Listing $listing, ?array $allowedTypes): Asset\Listing
     {
+        if ($allowedTypes === null) {
+            $allowedTypes = array_filter(Asset::getTypes(), static function ($type) {
+                return $type !== 'folder';
+            });
+        }
+
         if (count($allowedTypes) === 0) {
             return $listing;
         }

--- a/src/Service/Builder/DocumentListBuilder.php
+++ b/src/Service/Builder/DocumentListBuilder.php
@@ -75,8 +75,14 @@ class DocumentListBuilder implements DataBuilderInterface
         return $list;
     }
 
-    protected function addDocumentTypeRestriction(Document\Listing $listing, array $allowedTypes): Document\Listing
+    protected function addDocumentTypeRestriction(Document\Listing $listing, ?array $allowedTypes): Document\Listing
     {
+        if ($allowedTypes === null) {
+            $allowedTypes = array_filter(Document::getTypes(), static function ($type) {
+                return $type !== 'folder';
+            });
+        }
+
         if (count($allowedTypes) === 0) {
             return $listing;
         }

--- a/src/Service/Builder/ObjectListBuilder.php
+++ b/src/Service/Builder/ObjectListBuilder.php
@@ -76,8 +76,14 @@ class ObjectListBuilder implements DataBuilderInterface
         return $event->getListing();
     }
 
-    protected function addObjectTypeRestriction(DataObject\Listing $listing, array $allowedTypes): DataObject\Listing
+    protected function addObjectTypeRestriction(DataObject\Listing $listing, ?array $allowedTypes): DataObject\Listing
     {
+        if ($allowedTypes === null) {
+            $allowedTypes = array_filter(DataObject::getTypes(), static function ($type) {
+                return $type !== 'folder';
+            });
+        }
+
         if (count($allowedTypes) === 0) {
             return $listing;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | --

Since pimcore requires container services to determinate asset / document types, we need to move the assertion out of the compiler pass.
